### PR TITLE
sweet: sepolicy: Remove unused hal_power rules

### DIFF
--- a/sepolicy/private/hal_power.te
+++ b/sepolicy/private/hal_power.te
@@ -1,3 +1,2 @@
 binder_call(hal_power, hal_touchfeature_xiaomi_default)
-allow hal_power input_device:chr_file rw_file_perms;
 allow hal_power hal_touchfeature_xiaomi_hwservice:hwservice_manager find;


### PR DESCRIPTION
 * not only unused, but throws neverallow when used in
   combo with flipendo/turboadapter rules


libsepol.report_failure: neverallow on line 559 of system/sepolicy/public/app.te (or line 10874 of policy.conf) violated by allow turbo_adapter input_device:chr_file { ioctl read write lock append map open watch watch_reads };
libsepol.report_failure: neverallow on line 559 of system/sepolicy/public/app.te (or line 10874 of policy.conf) violated by allow flipendo input_device:chr_file { ioctl read write lock append map open watch watch_reads };
libsepol.check_assertions: 2 neverallow failures occurred
Error while expanding policy